### PR TITLE
add update_with_authentication service method

### DIFF
--- a/lib/docker/service.rb
+++ b/lib/docker/service.rb
@@ -48,6 +48,16 @@ class Docker::Service
     connection.post("/services/#{self.id}/update", query, body: opts.to_json)
   end
 
+  def update_with_authentication(opts = {}, creds = nil, conn = Docker.connection)
+    query = {
+      version:  info.dig("Version", "Index")
+    }
+
+    credentials = creds || Docker.creds || {}
+    headers = Docker::Util.build_auth_header(credentials)
+    conn.post("/services/#{self.id}/update", query, :body => opts.to_json, :headers => headers)
+  end
+
   def logs(opts = {})
     connection.get("/services/#{self.id}/logs", opts)
   end


### PR DESCRIPTION
We want to support providing registry authentication/header info to ensure that updated registry info is provided to service updates in addition to service creation.